### PR TITLE
docs(readme): 优化配置分享内容并新增社区板块

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@
 
 cdpnetool 是一款强大的网络请求拦截工具，通过 Chrome DevTools Protocol 实现对浏览器 HTTP/HTTPS 请求的精准控制和灵活修改。无需安装证书，无需编写代码，通过可视化界面即可完成复杂的网络调试任务。
 
-📦 **配置分享**：[cdpnetool-configs](https://github.com/241x/cdpnetool-configs) - 下载社区配置或分享你的配置
-
 **核心特性：**
 - ✅ 实时拦截浏览器网络请求和响应
 - ✅ 可视化规则配置，支持丰富的匹配条件和修改行为
@@ -29,6 +27,10 @@ cdpnetool 是一款强大的网络请求拦截工具，通过 Chrome DevTools Pr
 - ✅ 请求预览：全量流量查看，支持开启/关闭捕获
 - ✅ 系统设置：语言切换（中/英）、主题模式、浏览器配置
 - ✅ 无需证书：基于 CDP 协议直接控制浏览器
+
+## 社区
+
+[cdpnetool-configs](https://github.com/241x/cdpnetool-configs) 您可以 **寻找您需要的配置** 或 **分享您创作的配置** 
 
 ## 快速开始
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -19,8 +19,6 @@ English | [简体中文](./README.md)
 
 cdpnetool is a powerful network request interception tool that enables precise control and flexible modification of browser HTTP/HTTPS requests through the Chrome DevTools Protocol. No certificate installation, no code writing required - complete complex network debugging tasks through a visual interface.
 
-📦 **Configuration Sharing**: [cdpnetool-configs](https://github.com/241x/cdpnetool-configs) - Download community configs or share your own
-
 **Core Features:**
 - ✅ Real-time interception of browser network requests and responses
 - ✅ Visual rule configuration with rich matching conditions and modification behaviors
@@ -29,6 +27,10 @@ cdpnetool is a powerful network request interception tool that enables precise c
 - ✅ Request preview: full traffic viewing with capture on/off support
 - ✅ System settings: language switching (Chinese/English), theme mode, browser configuration
 - ✅ No certificate required: direct browser control based on CDP protocol
+
+## Community
+
+[cdpnetool-configs](https://github.com/241x/cdpnetool-configs) - **Find configurations you need** or **Share configurations you created**
 
 ## Quick Start
 


### PR DESCRIPTION
- 删除了README和README_EN中关于配置分享的重复描述
- 在两个文档中新增了“社区”版块
- “社区”版块提供链接引导用户寻找或分享cdpnetool配置
- 保持中英文版本内容结构一致
- 改善文档结构清晰度，提升用户体验