### PR TITLE
fix: 修复CDP请求pending缺陷：panic恢复、降级放行与data race消除

### DIFF
--- a/internal/adapter/cdp/interceptor.go
+++ b/internal/adapter/cdp/interceptor.go
@@ -92,6 +92,17 @@ func (i *Interceptor) Consume(ctx context.Context, client *cdp.Client, handler f
 
 		if i.pool != nil {
 			submitted := i.pool.Submit(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						i.log.Err(nil, "handler panic 捕获", "requestID", ev.RequestID, "panic", r)
+						// 尝试降级放行
+						if ev.ResponseStatusCode == nil {
+							_ = i.ContinueRequest(ctx, client, ev.RequestID)
+						} else {
+							_ = i.ContinueResponse(ctx, client, ev.RequestID)
+						}
+					}
+				}()
 				handler(ev)
 			})
 			if !submitted {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -139,9 +139,8 @@ func (e *Engine) evalCondition(req *domain.Request, c *rulespec.Condition) bool 
 		return false
 
 	case rulespec.ConditionResourceType:
-		// 直接比较 ResourceType（已经是规范化的小写字符串）
 		for _, v := range c.Values {
-			if string(req.ResourceType) == v {
+			if strings.EqualFold(string(req.ResourceType), v) {
 				return true
 			}
 		}

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -44,8 +44,6 @@ type Processor struct {
 	matchedAuditor *auditor.Auditor // 匹配事件审计器
 	trafficAuditor *auditor.Auditor // 全量流量审计器
 	log            logger.Logger
-	sessionID      string // 会话ID
-	targetID       string // 目标ID
 }
 
 // New 创建一个新的处理器
@@ -62,14 +60,8 @@ func New(t *tracker.Tracker, e *engine.Engine, matchedAud, trafficAud *auditor.A
 	}
 }
 
-// SetContext 设置会话和目标上下文
-func (p *Processor) SetContext(sessionID, targetID string) {
-	p.sessionID = sessionID
-	p.targetID = targetID
-}
-
 // ProcessRequest 处理请求阶段逻辑
-func (p *Processor) ProcessRequest(ctx context.Context, req *domain.Request) Result {
+func (p *Processor) ProcessRequest(ctx context.Context, sessionID, targetID string, req *domain.Request) Result {
 	p.log.Debug("[Processor] 开始处理请求", "requestID", req.ID, "url", req.URL, "method", req.Method)
 
 	matched := p.engine.Eval(req, rulespec.StageRequest)
@@ -112,10 +104,10 @@ func (p *Processor) ProcessRequest(ctx context.Context, req *domain.Request) Res
 
 				// Block 动作需立即记录审计（响应阶段不会再执行）
 				// 1. 全量流量审计
-				p.trafficAuditor.Record(p.sessionID, p.targetID, req, res.MockRes, "blocked", p.toRuleMatches(matched))
+				p.trafficAuditor.Record(sessionID, targetID, req, res.MockRes, "blocked", p.toRuleMatches(matched))
 				// 2. 匹配事件审计（仅匹配时记录）
 				if len(matched) > 0 {
-					p.matchedAuditor.Record(p.sessionID, p.targetID, req, res.MockRes, "blocked", p.toRuleMatches(matched))
+					p.matchedAuditor.Record(sessionID, targetID, req, res.MockRes, "blocked", p.toRuleMatches(matched))
 				}
 				p.log.Debug("[Processor] Block 执行完成", "requestID", req.ID)
 				return res
@@ -152,7 +144,7 @@ func (p *Processor) ProcessRequest(ctx context.Context, req *domain.Request) Res
 }
 
 // ProcessResponse 处理响应阶段逻辑
-func (p *Processor) ProcessResponse(ctx context.Context, reqID string, res *domain.Response) Result {
+func (p *Processor) ProcessResponse(ctx context.Context, sessionID, targetID, reqID string, res *domain.Response) Result {
 	p.log.Debug("[Processor] 开始处理响应", "requestID", reqID, "statusCode", res.StatusCode)
 
 	stateVal, ok := p.tracker.Get(reqID)
@@ -195,10 +187,10 @@ func (p *Processor) ProcessResponse(ctx context.Context, reqID string, res *doma
 	ruleMatches := p.toRuleMatches(allMatched)
 
 	// 1. 全量流量审计
-	p.trafficAuditor.Record(p.sessionID, p.targetID, state.Request, res, finalResult, ruleMatches)
+	p.trafficAuditor.Record(sessionID, targetID, state.Request, res, finalResult, ruleMatches)
 	// 2. 匹配事件审计（仅匹配时记录）
 	if len(allMatched) > 0 {
-		p.matchedAuditor.Record(p.sessionID, p.targetID, state.Request, res, finalResult, ruleMatches)
+		p.matchedAuditor.Record(sessionID, targetID, state.Request, res, finalResult, ruleMatches)
 	}
 	p.log.Debug("[Processor] 响应处理完成", "requestID", reqID, "finalResult", finalResult)
 

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -51,7 +51,7 @@ func TestProcessRequest_NoMatch(t *testing.T) {
 		Method: "GET",
 	}
 
-	result := p.ProcessRequest(context.Background(), req)
+	result := p.ProcessRequest(context.Background(), "test-session", "test-target", req)
 	if result.Action != processor.ActionPass {
 		t.Errorf("got action %v, want %v", result.Action, processor.ActionPass)
 	}
@@ -94,7 +94,7 @@ func TestProcessRequest_Block(t *testing.T) {
 		Method: "GET",
 	}
 
-	result := p.ProcessRequest(context.Background(), req)
+	result := p.ProcessRequest(context.Background(), "test-session", "test-target", req)
 	if result.Action != processor.ActionBlock {
 		t.Errorf("got action %v, want %v", result.Action, processor.ActionBlock)
 	}
@@ -143,7 +143,7 @@ func TestProcessRequest_ModifyHeader(t *testing.T) {
 		Headers: make(domain.Header),
 	}
 
-	result := p.ProcessRequest(context.Background(), req)
+	result := p.ProcessRequest(context.Background(), "test-session", "test-target", req)
 	if result.Action != processor.ActionModify {
 		t.Errorf("got action %v, want %v", result.Action, processor.ActionModify)
 	}
@@ -191,7 +191,7 @@ func TestProcessRequest_ModifyURL(t *testing.T) {
 		Method: "GET",
 	}
 
-	result := p.ProcessRequest(context.Background(), req)
+	result := p.ProcessRequest(context.Background(), "test-session", "test-target", req)
 	if result.Action != processor.ActionModify {
 		t.Errorf("got action %v, want %v", result.Action, processor.ActionModify)
 	}
@@ -213,7 +213,7 @@ func TestProcessResponse_NoMatch(t *testing.T) {
 	trafficAud := auditor.New(trafficChan, logger.NewNop())
 	p := processor.New(tr, eng, matchedAud, trafficAud, logger.NewNop())
 
-	result := p.ProcessResponse(context.Background(), "req1", &domain.Response{})
+	result := p.ProcessResponse(context.Background(), "test-session", "test-target", "req1", &domain.Response{})
 	if result.Action != processor.ActionPass {
 		t.Errorf("got action %v, want %v", result.Action, processor.ActionPass)
 	}
@@ -267,7 +267,7 @@ func TestProcessResponse_ModifyStatus(t *testing.T) {
 		Headers:    make(domain.Header),
 	}
 
-	result := p.ProcessResponse(context.Background(), "req1", res)
+	result := p.ProcessResponse(context.Background(), "test-session", "test-target", "req1", res)
 	if result.Action != processor.ActionModify {
 		t.Errorf("got action %v, want %v", result.Action, processor.ActionModify)
 	}
@@ -323,7 +323,7 @@ func TestProcessResponse_ModifyHeader(t *testing.T) {
 		Headers:    make(domain.Header),
 	}
 
-	result := p.ProcessResponse(context.Background(), "req1", res)
+	result := p.ProcessResponse(context.Background(), "test-session", "test-target", "req1", res)
 	if result.Action != processor.ActionModify {
 		t.Errorf("got action %v, want %v", result.Action, processor.ActionModify)
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -335,13 +335,10 @@ func (o *Orchestrator) handleEvent(state *sessionState, ts *cdp.TargetSession, e
 	}
 	o.log.Debug("[Orchestrator] 处理 CDP 事件", "requestID", ev.RequestID, "stage", stage, "url", ev.Request.URL, "method", ev.Request.Method)
 
-	// 设置上下文
-	state.processor.SetContext(string(state.id), string(ts.ID))
-
 	if ev.ResponseStatusCode == nil {
 		// 请求阶段
 		req := cdp.ToNeutralRequest(ev)
-		res := state.processor.ProcessRequest(state.ctx, req)
+		res := state.processor.ProcessRequest(state.ctx, string(state.id), string(ts.ID), req)
 		o.log.Debug("[Orchestrator] 请求处理结果", "requestID", ev.RequestID, "action", res.Action)
 		o.applyResult(state, ts, ev, res)
 	} else {
@@ -374,7 +371,7 @@ func (o *Orchestrator) handleEvent(state *sessionState, ts *cdp.TargetSession, e
 		}
 
 		resp := cdp.ToNeutralResponse(ev, body)
-		res := state.processor.ProcessResponse(state.ctx, string(ev.RequestID), resp)
+		res := state.processor.ProcessResponse(state.ctx, string(state.id), string(ts.ID), string(ev.RequestID), resp)
 		o.log.Debug("[Orchestrator] 响应处理结果", "requestID", ev.RequestID, "action", res.Action)
 		o.applyResult(state, ts, ev, res)
 	}
@@ -407,7 +404,12 @@ func (o *Orchestrator) applyResult(state *sessionState, ts *cdp.TargetSession, e
 			Body:            res.MockRes.Body,
 		})
 		if err != nil {
-			o.log.Err(err, "[Orchestrator] 执行 Block 响应失败", "requestID", id)
+			o.log.Err(err, "[Orchestrator] 执行 Block 响应失败，降级放行", "requestID", id)
+			if isRequest {
+				_ = state.interceptor.ContinueRequest(state.ctx, ts.Client, id)
+			} else {
+				_ = state.interceptor.ContinueResponse(state.ctx, ts.Client, id)
+			}
 		} else {
 			o.log.Debug("[Orchestrator] Block 执行成功", "requestID", id)
 		}
@@ -424,7 +426,8 @@ func (o *Orchestrator) applyResult(state *sessionState, ts *cdp.TargetSession, e
 				PostData:  res.ModifiedReq.Body,
 			})
 			if err != nil {
-				o.log.Err(err, "[Orchestrator] 执行请求修改失败", "requestID", id)
+				o.log.Err(err, "[Orchestrator] 执行请求修改失败，降级原样放行", "requestID", id)
+				_ = state.interceptor.ContinueRequest(state.ctx, ts.Client, id)
 			} else {
 				o.log.Debug("[Orchestrator] 请求修改成功", "requestID", id)
 			}


### PR DESCRIPTION
- Interceptor池化路径添加panic恢复+降级放行，防止worker死亡导致后续请求全部pending

- Block动作FulfillRequest失败后添加ContinueRequest/ContinueResponse降级放行

- 请求Modify动作ContinueRequest失败后添加原样ContinueRequest降级放行

- Processor.sessionID/targetID改为方法参数传递，消除多Target并发data race

- ResourceType条件匹配改为大小写不敏感比较(EqualFold)